### PR TITLE
Deny by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "s3_log_prefix" {
 variable "default_action"{
   description = "The default action for this WAF. Allowed values are ALLOW, BLOCK and COUNT."
   type = string
-  default = "ALLOW"
+  default = "BLOCK"
 }
 
 variable "geo_match_constraints" {


### PR DESCRIPTION
By default, we should block all traffic to the WAF. the rules are there to let traffic pass on match.